### PR TITLE
Fix typos in S4 episode

### DIFF
--- a/_episodes_rmd/05-s4.Rmd
+++ b/_episodes_rmd/05-s4.Rmd
@@ -164,8 +164,6 @@ Vice versa, we can also convert `data.frame` objects to `DataFrame` using the `a
 as(df1, "DataFrame")
 ```
 
-and vice versa
-
 ## Differences with the base data.frame
 
 The most notable exceptions have to do with handling of row names.

--- a/_episodes_rmd/05-s4.Rmd
+++ b/_episodes_rmd/05-s4.Rmd
@@ -140,7 +140,7 @@ Specifically, the `DataFrame` supports the storage of any type of object (with `
 On the whole, the `DataFrame` class provides a formal definition of an S4 class that behaves very similarly to `data.frame`, in terms of construction, subsetting, splitting, combining, etc.
 
 The `DataFrame()` constructor function should be used to create new objects, comparably to the `data.frame()` equivalent in base R.
-The help page for the function, accessible as `?DataFrame`, ca be consulted for more information.
+The help page for the function, accessible as `?DataFrame`, can be consulted for more information.
 
 ```{r}
 DF1 <- DataFrame(

--- a/_episodes_rmd/05-s4.Rmd
+++ b/_episodes_rmd/05-s4.Rmd
@@ -158,6 +158,14 @@ df1 <- as.data.frame(DF1)
 df1
 ```
 
+Vice versa, we can also convert `data.frame` objects to `DataFrame` using the `as()` function.
+
+```{r}
+as(df1, "DataFrame")
+```
+
+and vice versa
+
 ## Differences with the base data.frame
 
 The most notable exceptions have to do with handling of row names.

--- a/reference.md
+++ b/reference.md
@@ -19,7 +19,7 @@ ExperimentData package
     Experiment data packages can be explored on the [biocViews page][bioc-experimentdata].
 
 S4 class
-:   R has three object-oriented programming (OOP) systems: S3, S4 and R6 (or Reference Classs).
+:   R has three object-oriented programming (OOP) systems: S3, S4 and R6 (or Reference Classes).
     S4 is system that defines formal classes, using an implementation that is stricter than the S3 class system.
     Classes define the conceptual structure of S4 objects, while S4 objects represent practical instances of their class. See [S4 object](#s4-object).
     

--- a/reference.md
+++ b/reference.md
@@ -19,7 +19,7 @@ ExperimentData package
     Experiment data packages can be explored on the [biocViews page][bioc-experimentdata].
 
 S4 class
-:   R has three object oriented (OO) systems: S3, S4 and R5.
+:   R has three object-oriented programming (OOP) systems: S3, S4 and R6 (or Reference Classs).
     S4 is system that defines formal classes, using an implementation that is stricter than the S3 class system.
     Classes define the conceptual structure of S4 objects, while S4 objects represent practical instances of their class. See [S4 object](#s4-object).
     


### PR DESCRIPTION
- Typo in the glossary: ~~`R5`~~ --> `R6` (and also mention Reference Classes)
- Small typo in the S4 Rmd
- Proposal: add conversion from `data.frame` to `DataFrame`