### PR TITLE
Only download data once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ install-rmd-deps:
 	@${SHELL} bin/install_r_deps.sh
 
 ## * lesson-md        : convert Rmarkdown files to markdown
-lesson-md : ${RMD_DST}
+lesson-md : ${RMD_DST} _episodes_rmd/data/actb.gtf
 
 _episodes/%.md: _episodes_rmd/%.Rmd install-rmd-deps
 	@mkdir -p _episodes
@@ -160,3 +160,6 @@ lesson-fixme :
 ## * commands         : show all commands.
 commands :
 	@sed -n -e '/^##/s|^##[[:space:]]*||p' $(MAKEFILE_LIST)
+
+_episodes_rmd/data/actb.gtf: _episodes_rmd/download_data.R
+	Rscript $<

--- a/_episodes_rmd/06-biological-sequences.Rmd
+++ b/_episodes_rmd/06-biological-sequences.Rmd
@@ -15,9 +15,6 @@ keypoints:
 - "The `BSgenome` package provides genome sequences for a range of model organisms immediately available as Bioconductor objects."
 ---
 
-```{r, echo=FALSE, purl=FALSE, message=FALSE}
-source("download_data.R")
-```
 
 ```{r, include=FALSE}
 source("../bin/chunk-options.R")

--- a/_episodes_rmd/07-genomic-ranges.Rmd
+++ b/_episodes_rmd/07-genomic-ranges.Rmd
@@ -16,9 +16,6 @@ keypoints:
 - "The `rtracklayer` package provides functions to import and export genomic ranges from and to common genomic file formats."
 ---
 
-```{r, echo=FALSE, purl=FALSE, message=FALSE}
-source("download_data.R")
-```
 
 ```{r, include=FALSE}
 source("../bin/chunk-options.R")


### PR DESCRIPTION
Rather than having a hidden download as part of the Rmarkdown files, I'd be inclined to put the downloading in the Makefile so that it doesn't happen every time you build the md